### PR TITLE
rewrite the roll of nodes to spin up a node before draining the instance

### DIFF
--- a/cmd/drain/drain.go
+++ b/cmd/drain/drain.go
@@ -12,21 +12,23 @@ var (
 	nodeName       string
 	gracePeriod    time.Duration
 	skipValidation bool
+	nodeTermination	 bool
 )
 
 // NewCommand sets up the move command
-func NewCommand(kubectl *kubernetes.Client) *cobra.Command {
+func NewCommand(kubectl *kubernetes.Client, verbose *bool) *cobra.Command {
 	c := &cobra.Command{
 		Use:   "drain",
 		Short: "",
 		Long:  "",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return drain.Run(kubectl, nodeName, gracePeriod, skipValidation)
+			return drain.Run(kubectl, nodeName, gracePeriod, skipValidation, nodeTermination, *verbose)
 		},
 	}
 	c.Flags().StringVar(&nodeName, "node", "", "The node that dextre should drain in a safe manner (required)")
 	c.MarkFlagRequired("node")
 	c.Flags().BoolVar(&skipValidation, "skip-validation", false, "Don't ask for validations")
+	c.Flags().BoolVar(&nodeTermination, "terminate-node", false, "Terminate the AWS instance in the autoscaling group")
 	c.Flags().DurationVar(&gracePeriod, "grace-period", (30 * time.Second), "pod grace-period")
 
 	return c

--- a/cmd/roll/nodes.go
+++ b/cmd/roll/nodes.go
@@ -7,21 +7,23 @@ import (
 )
 
 // NewCommand sets up the move command
-func nodesCommand(kubectl *kubernetes.Client) *cobra.Command {
-	var role string
-	var label string
+func nodesCommand(kubectl *kubernetes.Client, verbose *bool) *cobra.Command {
+	var instanceGroup string
+	var cluster string
 
 	c := &cobra.Command{
 		Use:   "nodes",
 		Short: "",
 		Long:  "",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return roll.Nodes(kubectl, role, label)
+			return roll.Nodes(kubectl, instanceGroup, cluster, *verbose)
 		},
 	}
-	c.Flags().StringVar(&role, "role", "", "Role type of the nodes to be rolled")
-	c.MarkFlagRequired("role")
+	c.Flags().StringVar(&instanceGroup, "kops-instance-group", "", "kops instance group to perfrom the rolling on")
+	c.MarkFlagRequired("kops-instance-group")
 	c.Flags().StringVar(&label, "label", "", "label of the nodes to be rolled")
+	c.Flags().StringVar(&cluster, "cluster", "", "the name of the kops cluster")
+	c.MarkFlagRequired("cluster")
 
 	return c
 }

--- a/cmd/roll/pods.go
+++ b/cmd/roll/pods.go
@@ -15,13 +15,13 @@ var (
 )
 
 // NewCommand sets up the move command
-func podsCommand(kubectl *kubernetes.Client) *cobra.Command {
+func podsCommand(kubectl *kubernetes.Client, verbose *bool) *cobra.Command {
 	c := &cobra.Command{
 		Use:   "pods",
 		Short: "",
 		Long:  "",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return roll.Pods(kubectl, label, namespace, gracePeriod)
+			return roll.Pods(kubectl, label, namespace, gracePeriod, *verbose)
 		},
 	}
 	c.Flags().StringVar(&label, "label", "", "The labels that should be restarted on the form: type=service")

--- a/cmd/roll/roll.go
+++ b/cmd/roll/roll.go
@@ -6,15 +6,15 @@ import (
 )
 
 // NewCommand sets up the move command
-func NewCommand(kubectl *kubernetes.Client) *cobra.Command {
+func NewCommand(kubectl *kubernetes.Client, verbose *bool) *cobra.Command {
 	c := &cobra.Command{
 		Use:   "roll",
 		Short: "",
 		Long:  "",
 	}
 	c.AddCommand(
-		podsCommand(kubectl),
-		nodesCommand(kubectl),
+		podsCommand(kubectl, verbose),
+		nodesCommand(kubectl, verbose),
 	)
 
 	return c

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,8 +20,10 @@ func NewCommand(name string) (*cobra.Command, error) {
 	}
 
 	var kubeConfig string
+	var verbose bool
 	flags := c.PersistentFlags()
 	flags.StringVar(&kubeConfig, "kubeconfig", "", "kubeconfig file")
+	flags.BoolVar(&verbose, "verbose", false, "verbose output")
 
 	kubectl, err := kubernetes.NewClient(kubeConfig)
 	if err != nil {
@@ -29,8 +31,8 @@ func NewCommand(name string) (*cobra.Command, error) {
 	}
 
 	c.AddCommand(
-		drain.NewCommand(kubectl),
-		roll.NewCommand(kubectl),
+		drain.NewCommand(kubectl, &verbose),
+		roll.NewCommand(kubectl, &verbose),
 	)
 	return c, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/json-iterator/go v1.1.5
 	github.com/mattn/go-colorable v0.0.9
 	github.com/mattn/go-isatty v0.0.4
+	github.com/mattn/go-runewidth v0.0.4 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd
 	github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742
 	github.com/petar/GoLLRB v0.0.0-20130427215148-53be0d36a84c
@@ -32,6 +33,7 @@ require (
 	golang.org/x/text v0.3.0
 	golang.org/x/time v0.0.0-20181108054448-85acf8d2951c
 	google.golang.org/appengine v1.3.0
+	gopkg.in/cheggaaa/pb.v1 v1.0.27
 	gopkg.in/inf.v0 v0.9.1
 	gopkg.in/yaml.v2 v2.2.2
 	k8s.io/api v0.0.0-20181130031204-d04500c8c3dd

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,8 @@ github.com/mattn/go-colorable v0.0.9 h1:UVL0vNpWh04HeJXV0KLcaT7r06gOH2l4OW6ddYRU
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-isatty v0.0.4 h1:bnP0vzxcAdeI1zdubAl5PjU6zsERjGZb7raWodagDYs=
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
+github.com/mattn/go-runewidth v0.0.4 h1:2BvfKmzob6Bmd4YsL0zygOqfdFnK7GR4QL06Do4/p7Y=
+github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742 h1:Esafd1046DLDQ0W1YjYsBW+p8U2u7vzgW2SQVmlNazg=
@@ -58,6 +60,8 @@ golang.org/x/time v0.0.0-20181108054448-85acf8d2951c h1:fqgJT0MGcGpPgpWU7VRdRjuA
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 google.golang.org/appengine v1.3.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/cheggaaa/pb.v1 v1.0.27 h1:kJdccidYzt3CaHD1crCFTS1hxyhSi059NhOFUf03YFo=
+gopkg.in/cheggaaa/pb.v1 v1.0.27/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=

--- a/pkg/aws/autoscaling.go
+++ b/pkg/aws/autoscaling.go
@@ -1,6 +1,8 @@
 package aws
 
 import (
+	"errors"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 )
@@ -72,7 +74,7 @@ func (c *Client) GetAutoScalingGroup(instanceGroup, cluster string) (AutoScaling
 			}, nil
 		}
 	}
-	return AutoScalingGroupStruct{}, nil
+	return AutoScalingGroupStruct{}, errors.New("not found")
 }
 
 func (c *Client) IncrementCapacity(autoScalingGroup AutoScalingGroupStruct) error {

--- a/pkg/aws/autoscaling.go
+++ b/pkg/aws/autoscaling.go
@@ -5,7 +5,16 @@ import (
 	"github.com/aws/aws-sdk-go/service/autoscaling"
 )
 
-func (c *Client) TerminateInstance(instanceID string) error {
+type AutoScalingGroupStruct struct {
+	AutoScalingGroupARN  string
+	AutoScalingGroupName string
+	DesiredCapacity      int64
+	MinSize              int64
+	MaxSize              int64
+	DefaultCooldown      int64
+}
+
+func (c *Client) TerminateInstanceKeepDesiredCapacity(instanceID string) error {
 	auto := autoscaling.New(c.Session)
 	input := &autoscaling.TerminateInstanceInAutoScalingGroupInput{
 		InstanceId:                     aws.String(instanceID),
@@ -16,5 +25,83 @@ func (c *Client) TerminateInstance(instanceID string) error {
 	if err != nil {
 		return err
 	}
+	return nil
+}
+func (c *Client) TerminateInstanceDecrementDesiredCapacity(instanceID string) error {
+	auto := autoscaling.New(c.Session)
+	input := &autoscaling.TerminateInstanceInAutoScalingGroupInput{
+		InstanceId:                     aws.String(instanceID),
+		ShouldDecrementDesiredCapacity: aws.Bool(true),
+	}
+
+	_, err := auto.TerminateInstanceInAutoScalingGroup(input)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *Client) GetAutoScalingGroup(instanceGroup, cluster string) (AutoScalingGroupStruct, error) {
+	auto := autoscaling.New(c.Session)
+	input := &autoscaling.DescribeAutoScalingGroupsInput{}
+	asgs, err := auto.DescribeAutoScalingGroups(input)
+	if err != nil {
+		return AutoScalingGroupStruct{}, err
+	}
+
+	for _, a := range asgs.AutoScalingGroups {
+		var clusterMatch, instanceGroupMatch bool
+		for _, t := range a.Tags {
+			// Is it the correct cluster?
+			if (*t.Key == "KubernetesCluster") && (*t.Value == cluster) {
+				clusterMatch = true
+			}
+			// Is the label correct?
+			if (*t.Key == "k8s.io/cluster-autoscaler/node-template/label/kops.k8s.io/instancegroup") && (*t.Value == instanceGroup) {
+				instanceGroupMatch = true
+			}
+		}
+		if instanceGroupMatch && clusterMatch {
+			return AutoScalingGroupStruct{
+				AutoScalingGroupARN:  *a.AutoScalingGroupARN,
+				AutoScalingGroupName: *a.AutoScalingGroupName,
+				DesiredCapacity:      *a.DesiredCapacity,
+				MinSize:              *a.MinSize,
+				MaxSize:              *a.MaxSize,
+				DefaultCooldown:      *a.DefaultCooldown,
+			}, nil
+		}
+	}
+	return AutoScalingGroupStruct{}, nil
+}
+
+func (c *Client) IncrementCapacity(autoScalingGroup AutoScalingGroupStruct) error {
+	auto := autoscaling.New(c.Session)
+	input := &autoscaling.UpdateAutoScalingGroupInput{
+		AutoScalingGroupName: aws.String(autoScalingGroup.AutoScalingGroupName),
+		DesiredCapacity:      aws.Int64(autoScalingGroup.DesiredCapacity + 1),
+		MaxSize:              aws.Int64(autoScalingGroup.DesiredCapacity + 1),
+		DefaultCooldown:      aws.Int64(0),
+	}
+	_, err := auto.UpdateAutoScalingGroup(input)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *Client) RestoreValuesForAutoScalingGroup(autoScalingGroup AutoScalingGroupStruct) error {
+	auto := autoscaling.New(c.Session)
+	input := &autoscaling.UpdateAutoScalingGroupInput{
+		AutoScalingGroupName: aws.String(autoScalingGroup.AutoScalingGroupName),
+		MaxSize:              aws.Int64(autoScalingGroup.MaxSize),
+		DefaultCooldown:      aws.Int64(autoScalingGroup.DefaultCooldown),
+	}
+	_, err := auto.UpdateAutoScalingGroup(input)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/pkg/drain/drain.go
+++ b/pkg/drain/drain.go
@@ -77,9 +77,9 @@ func Run(kubectl *kubernetes.Client, nodeName string, gracePeriod time.Duration,
 	ui.Print(fmt.Sprintf("[✓] %d pods evicted!", len(systemPods)+len(regularPods)), true)
 
 	if !nodeTermination {
-		retun nil
+		return nil
 	}
-	
+
 	if !skipValidation {
 		fmt.Println("")
 		fmt.Printf("Do you want to continue and terminate the node? ")

--- a/pkg/drain/drain.go
+++ b/pkg/drain/drain.go
@@ -4,16 +4,16 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/fatih/color"
 	dextreaws "github.com/lunarway/dextre/pkg/aws"
 	"github.com/lunarway/dextre/pkg/kubernetes"
 	"github.com/lunarway/dextre/pkg/ui"
 	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 )
 
 //Run: executes the drain command
-func Run(kubectl *kubernetes.Client, nodeName string, gracePeriod time.Duration, skipValidation bool) error {
+func Run(kubectl *kubernetes.Client, nodeName string, gracePeriod time.Duration, skipValidation, nodeTermination, verbose bool) error {
 
 	// Find the node in the cluster
 	node, err := kubectl.GetNode(nodeName)
@@ -40,8 +40,9 @@ func Run(kubectl *kubernetes.Client, nodeName string, gracePeriod time.Duration,
 	}
 
 	// Print the pods to be evicted; both system and regular
-	ui.PrintPodList(systemPods, "System pods to be evicted", false)
-	ui.PrintPodList(regularPods, "Regular pods to be evicted", true)
+	ui.PrintPodList(systemPods, "System pods to be evicted", false,verbose)
+	ui.PrintPodList(regularPods, "Regular pods to be evicted", true, verbose)
+
 
 	if !skipValidation {
 		fmt.Printf("Are you sure you want to evict all pods on the node? ")
@@ -63,66 +64,66 @@ func Run(kubectl *kubernetes.Client, nodeName string, gracePeriod time.Duration,
 		return err
 	}
 
-	fmt.Println("")
-	color.Yellow("Cordon\n")
-	fmt.Printf("[✓] %s cordoned\n\n", node.ObjectMeta.Name)
+	ui.Print("", verbose)
+	ui.PrintTitle("Cordon\n", verbose)
+	ui.Print(fmt.Sprintf("[✓] %s cordoned\n\n", node.ObjectMeta.Name), verbose)
 
-	// put this in UI as a header function
-	color.Yellow("Evict Regular pods")
-	rollPods(kubectl, regularPods, gracePeriod)
+	ui.PrintTitle("Evict Regular pods\n", verbose)
+	rollPods(kubectl, regularPods, gracePeriod, verbose)
 
-	fmt.Println("")
-	color.Yellow("Evict System pods")
-	rollPods(kubectl, systemPods, gracePeriod)
+	ui.Print("", verbose)
+	ui.PrintTitle("Evict System pods\n", verbose)
+	rollPods(kubectl, systemPods, gracePeriod, verbose)
 
-	fmt.Println("")
-	color.Green("[✓] All pods evicted!\n")
+	ui.Print("", verbose)
+	ui.Print(fmt.Sprintf("[✓] %d pods evicted!",len(systemPods)+len(regularPods)), true)
 
-	if !skipValidation {
-		fmt.Println("")
-		fmt.Printf("Do you want to continue and terminate the node? ")
-		ok, err := ui.AskForConfirmation()
+	if nodeTermination {
+		if !skipValidation {
+			fmt.Println("")
+			fmt.Printf("Do you want to continue and terminate the node? ")
+			ok, err := ui.AskForConfirmation()
+			if err != nil {
+				return err
+			}
+	
+			// user stopped the flow
+			if !ok {
+				return nil
+			}
+		}
+	
+		ui.Print("",verbose)
+		ui.PrintTitle("Node termination:\n",verbose)
+	
+		// Create the client
+		client, err := dextreaws.NewClient("eu-west-1")
+	
 		if err != nil {
 			return err
 		}
-
-		// user stopped the flow
-		if !ok {
-			return nil
+	
+		instanceID, err := client.GetInstanceId(nodeName)
+		if err != nil {
+			return err
 		}
-	}
-
-	fmt.Println("")
-	color.Yellow("Node termination:\n")
-
-	// Create the client
-	client, err := dextreaws.NewClient("eu-west-1")
-
-	if err != nil {
-		return err
-	}
-
-	instanceID, err := client.GetInstanceId(nodeName)
-	if err != nil {
-		return err
-	}
-
-	fmt.Printf("%-25s %s\n", "Private DNS:", nodeName)
-	fmt.Printf("%-25s %s\n", "Instance ID:", instanceID)
-
-	err = client.TerminateInstance(instanceID)
-	if err != nil {
-		return err
-	}
-
-	fmt.Println("")
-	color.Green("[✓] Node has been terminated!\n")
-
+	
+		ui.Print(fmt.Sprintf("%-25s %s", "Private DNS:", nodeName),verbose)
+		ui.Print(fmt.Sprintf("%-25s %s", "Instance ID:", instanceID),verbose)
+	
+		err = client.TerminateInstanceKeepDesiredCapacity(instanceID)
+		if err != nil {
+			return err
+		}
+	
+		ui.Print("\n", verbose)
+		ui.Print("[✓] Node has been terminated!\n", true)
+	} 
 	return nil
 }
 
-func rollPods(kubectl *kubernetes.Client, pods []v1.Pod, gracePeriod time.Duration) error {
-	table := ui.NewTable("[-]", "EVICTED", "NEW", "NODE")
+func rollPods(kubectl *kubernetes.Client, pods []v1.Pod, gracePeriod time.Duration, verbose bool) error {
+	table := ui.NewTable("[-]", "EVICTED POD", "NEW POD", "NEW NODE", verbose)
 	graceP := int64(gracePeriod.Seconds())
 
 	// Evict regular pods first.
@@ -145,6 +146,7 @@ func rollPods(kubectl *kubernetes.Client, pods []v1.Pod, gracePeriod time.Durati
 			table.CommitRow("[✓]", pod.Name, newPod.Name, newPod.Spec.NodeName)
 		}
 		table.DiscardRow()
+
 	}
 	return nil
 }

--- a/pkg/roll/nodes.go
+++ b/pkg/roll/nodes.go
@@ -50,6 +50,7 @@ func Nodes(kubectl *kubernetes.Client, instanceGroup, cluster string, verbose bo
 	}
 
 	for _, node := range rollableNodes {
+		spinner.Start()
 		ui.PrintTitle(fmt.Sprintf("[-] %s:",node.Name),true)
 
 		// Get the list of current nodes in the cluster

--- a/pkg/roll/nodes.go
+++ b/pkg/roll/nodes.go
@@ -2,89 +2,123 @@ package roll
 
 import (
 	"fmt"
-	"strings"
-
-	"github.com/fatih/color"
+	"time"
+	dextreaws "github.com/lunarway/dextre/pkg/aws"
 	"github.com/lunarway/dextre/pkg/drain"
 	"github.com/lunarway/dextre/pkg/kubernetes"
 	"github.com/lunarway/dextre/pkg/ui"
 	"k8s.io/api/core/v1"
+	"github.com/briandowns/spinner"
 )
 
 //Run: executes the drain command
-func Nodes(kubectl *kubernetes.Client, role, label string) error {
-	// Output the banner
-	ui.PrintBanner("dextre")
+func Nodes(kubectl *kubernetes.Client, instanceGroup, cluster string, verbose bool) error {
+	
+	spinner := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
 
+	// Get nodes in the kubernetes cluster
 	nodes, err := kubectl.ListNodes()
 	if err != nil {
 		return err
 	}
 
+	// Find the nodes to roll by matching label and role
 	var rollableNodes []v1.Node
 	var discardedNodes []v1.Node
 	for _, node := range nodes.Items {
-		if node.Labels["kubernetes.io/role"] == role {
-			if label == "" {
-				rollableNodes = append(rollableNodes, node)
-			} else {
-				labelSlice := strings.Split(label, "=")
-				if node.Labels[labelSlice[0]] == labelSlice[1] {
-					rollableNodes = append(rollableNodes, node)
-				} else {
-					discardedNodes = append(discardedNodes, node)
-				}
-			}
+		if node.Labels["kops.k8s.io/instancegroup"] == instanceGroup {
+			rollableNodes = append(rollableNodes, node)
 		} else {
 			discardedNodes = append(discardedNodes, node)
 		}
 	}
 
-	fmt.Printf("Nodes to be rolled: %d, Discarded: %d\n", len(rollableNodes), len(discardedNodes))
-	fmt.Println("")
-
-	color.Yellow("List of nodes to be rolled:\n")
-
+	ui.PrintTitle("OVERVIEW:\n", true)
+	ui.Print(fmt.Sprintf("Nodes to be rolled: %d", len(rollableNodes)),true)
 	for _, node := range rollableNodes {
-		fmt.Printf("> %s\n", node.Name)
+		ui.Print(fmt.Sprintf("> %s",node.Name),true)
+	}
+	ui.Print(fmt.Sprintf("Discarded nodes: %d", len(discardedNodes)),true)
+
+	ui.Print("",true)
+	ui.PrintTitle("PROGRESS:\n",true)
+
+	// Create AWS client
+	client, err := dextreaws.NewClient("eu-west-1")
+	if err != nil {
+		return err
 	}
 
-	fmt.Println("")
-	color.Yellow("PROCESS:\n")
-
 	for _, node := range rollableNodes {
+		ui.PrintTitle(fmt.Sprintf("[-] %s:",node.Name),true)
 
-		// Drain the Node
-		fmt.Println("")
-		drain.Run(kubectl, node.Name, 30, true)
-
-		// Wait for the node to be terminated
-		err = kubectl.WaitForNodeToTerminate(node)
-		if err != nil {
-			return err
-		}
-		color.Green("[✓] Node has been removed from the cluster\n")
-
-		// Get the new list of nodes
+		// Get the list of current nodes in the cluster
 		nodes, err = kubectl.ListNodes()
 		if err != nil {
 			return err
 		}
 
-		// Wait and identify the new node
-		newNode, err := kubectl.IdentifyNewNode(nodes.Items, role, label)
+		// Identify the correct autoscaling group
+		asg, err := client.GetAutoScalingGroup(instanceGroup, cluster)
 		if err != nil {
 			return err
 		}
-		color.Green("[✓] %s has been added to the cluster\n", newNode.Name)
+		ui.Print(fmt.Sprintf("[✓] AWS Autoscaling group located: %s",asg.AutoScalingGroupName), true)
+
+		// Increment the desired number of instances
+		err = client.IncrementCapacity(asg)
+		if err != nil {
+			return err
+		}
+		ui.Print(fmt.Sprintf("[✓] Increasing DesiredCapacity of %s from %d nodes to %d nodes and DefaultCooldown to %d",asg.AutoScalingGroupName, asg.DesiredCapacity, asg.DesiredCapacity+1,0), true)
+
+		// Wait and identify the new node
+		newNode, err := kubectl.IdentifyNewNode(nodes.Items, instanceGroup)
+		if err != nil {
+			return err
+		}
+		ui.Print(fmt.Sprintf("[✓] %s added to the cluster",newNode.Name), true)
 
 		// Wait for the new node to enter Ready state
 		err = kubectl.WaitForNewNodeToBeReady(newNode)
 		if err != nil {
 			return err
 		}
-		color.Green("[✓] %s is now READY\n", newNode.Name)
+		ui.Print(fmt.Sprintf("[✓] %s is now in state: Ready",newNode.Name), true)
 
+		// Drain the Node
+		drain.Run(kubectl, node.Name, 30, true, false, verbose)
+
+		// Get the AWS InstanceId
+		instanceID, err := client.GetInstanceId(node.Name)
+		if err != nil {
+			return err
+		}
+
+		// Terminate Decrement DesiredCapacity
+		err = client.TerminateInstanceDecrementDesiredCapacity(instanceID)
+		if err != nil {
+			return err
+		}
+		ui.Print(fmt.Sprintf("[✓] %s will now be terminated",node.Name), true)
+
+		// Wait for the node to be terminated
+		err = kubectl.WaitForNodeToTerminate(node)
+		if err != nil {
+			return err
+		}
+		ui.Print(fmt.Sprintf("[✓] %s is now removed from the cluster",node.Name), true)
+
+		// RESTORE ASG MAXSIZE
+		err = client.RestoreValuesForAutoScalingGroup(asg)
+		if err != nil {
+			return err
+		}
+		ui.Print(fmt.Sprintf("[✓] Restored AutoScalingGroup %s defaults. MaxSize=%d and DefaultCooldown=%d",asg.AutoScalingGroupName, asg.MaxSize, asg.DefaultCooldown), true)
+
+		// Interval between node roll
+		time.Sleep(5 * time.Second) 
+		spinner.Stop()
 	}
 
 	return nil

--- a/pkg/roll/pods.go
+++ b/pkg/roll/pods.go
@@ -12,18 +12,16 @@ import (
 )
 
 //Run: executes the drain command
-func Pods(kubectl *kubernetes.Client, label string, namespace string, gracePeriod time.Duration) error {
-	// Output the banner
-	ui.PrintBanner("dextre")
+func Pods(kubectl *kubernetes.Client, label string, namespace string, gracePeriod time.Duration, verbose bool) error {
 
 	pods, err := kubectl.GetPodsWithLabel(label, namespace)
 	if err != nil {
 		return err
 	}
 
-	ui.PrintPodList(pods.Items, "Pods to be restarted", false)
+	ui.PrintPodList(pods.Items, "Pods to be restarted", false, verbose)
 
-	fmt.Printf("Are you sure you want to restart the pods? ")
+	fmt.Printf("Are you sure you want to roll the pods? ")
 
 	ok, err := ui.AskForConfirmation()
 	if err != nil {
@@ -37,16 +35,16 @@ func Pods(kubectl *kubernetes.Client, label string, namespace string, gracePerio
 
 	// restartPods
 	fmt.Println("")
-	restartPods(kubectl, pods.Items, gracePeriod)
+	rollPods(kubectl, pods.Items, gracePeriod, verbose)
 
 	fmt.Println("")
-	color.Green("[✓] All pods restarted!\n")
+	color.Green("[✓] All pods rolled!\n")
 
 	return nil
 }
 
-func restartPods(kubectl *kubernetes.Client, pods []v1.Pod, gracePeriod time.Duration) error {
-	table := ui.NewTable("[-]", "EVICTED", "NEW", "NODE")
+func rollPods(kubectl *kubernetes.Client, pods []v1.Pod, gracePeriod time.Duration, verbose bool) error {
+	table := ui.NewTable("[-]", "EVICTED", "NEW POD", "NEW NODE", verbose)
 	graceP := int64(gracePeriod.Seconds())
 
 	// Evict regular pods first.

--- a/pkg/ui/ui.go
+++ b/pkg/ui/ui.go
@@ -19,20 +19,24 @@ type Table struct {
 	c4Width      int
 	formatString string
 	spinner      *spinner.Spinner
+	verbose      bool
 }
 
 // this is a UI thing as well - struct Table Row Header - add column widtch
 
-func NewTable(c1Title, c2Title, c3Title, c4Title string) Table {
+func NewTable(c1Title, c2Title, c3Title, c4Title string, verbose bool) Table {
 	table := Table{
 		c1Width: 4,
 		c2Width: 45,
 		c3Width: 45,
 		c4Width: 50,
 		spinner: spinner.New(spinner.CharSets[9], 100*time.Millisecond),
+		verbose: verbose,
 	}
 	table.formatString = fmt.Sprintf("%%-%ds %%-%ds %%-%ds %%-%ds\n", table.c1Width, table.c2Width, table.c3Width, table.c4Width)
-	fmt.Printf(table.printRow(c1Title, c2Title, c3Title, c4Title))
+	if table.verbose {
+		fmt.Printf(table.printRow(c1Title, c2Title, c3Title, c4Title))
+	}
 	return table
 }
 
@@ -41,16 +45,34 @@ func (t Table) printRow(c1, c2, c3, c4 string) string {
 }
 
 func (t Table) PrepareRow() {
-	t.spinner.Start()
+	if t.verbose {
+		t.spinner.Start()
+	}
 }
 
 func (t Table) DiscardRow() {
-	t.spinner.Stop()
+	if t.verbose {
+		t.spinner.Stop()
+	}
 }
 
 func (t Table) CommitRow(c1, c2, c3, c4 string) {
-	t.spinner.FinalMSG = t.printRow(c1, c2, c3, c4)
-	t.spinner.Stop()
+	if t.verbose {
+		t.spinner.FinalMSG = t.printRow(c1, c2, c3, c4)
+		t.spinner.Stop()
+	}
+}
+
+func PrintTitle(title string, verbose bool) {
+	if verbose {
+		color.Yellow(title)
+	}
+}
+
+func Print(title string, verbose bool) {
+	if verbose {
+		fmt.Println(title)
+	}
 }
 
 func PrintBanner(title string) {
@@ -59,16 +81,18 @@ func PrintBanner(title string) {
 	fmt.Println("")
 }
 
-func PrintPodList(pods []v1.Pod, title string, namespace bool) {
-	color.Yellow(title + "\n")
-	for _, pod := range pods {
-		if namespace {
-			fmt.Printf("> %s (%s)\n", pod.Name, pod.Namespace)
-		} else {
-			fmt.Printf("> %s\n", pod.Name)
+func PrintPodList(pods []v1.Pod, title string, namespace, verbose bool) {
+	if verbose {
+		color.Yellow(title + "\n")
+		for _, pod := range pods {
+			if namespace {
+				fmt.Printf("> %s (%s)\n", pod.Name, pod.Namespace)
+			} else {
+				fmt.Printf("> %s\n", pod.Name)
+			}
 		}
+		fmt.Println("")
 	}
-	fmt.Println("")
 }
 
 func AskForConfirmation() (bool, error) {

--- a/pkg/ui/ui.go
+++ b/pkg/ui/ui.go
@@ -7,7 +7,7 @@ import (
 	"github.com/CrowdSurge/banner"
 	"github.com/briandowns/spinner"
 	"github.com/fatih/color"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 )
 
 type Table struct {
@@ -82,17 +82,18 @@ func PrintBanner(title string) {
 }
 
 func PrintPodList(pods []v1.Pod, title string, namespace, verbose bool) {
-	if verbose {
-		color.Yellow(title + "\n")
-		for _, pod := range pods {
-			if namespace {
-				fmt.Printf("> %s (%s)\n", pod.Name, pod.Namespace)
-			} else {
-				fmt.Printf("> %s\n", pod.Name)
-			}
-		}
-		fmt.Println("")
+	if !verbose {
+		return
 	}
+	color.Yellow(title + "\n")
+	for _, pod := range pods {
+		if namespace {
+			fmt.Printf("> %s (%s)\n", pod.Name, pod.Namespace)
+		} else {
+			fmt.Printf("> %s\n", pod.Name)
+		}
+	}
+	fmt.Println("")
 }
 
 func AskForConfirmation() (bool, error) {


### PR DESCRIPTION
This PR changes the `dextre roll nodes` command significantly. 

First of all the input arguments are changed to accept `--kops-instance-group` and `--cluster` instead of `--role` and `--label`. This change is required to be able to strange the update strategy and be able to identify the correct autoscaling group to manipulate.

The new roll nodes strategy is as follows:
- Detect the AWS AutoScaling group
- Increment DesiredCapacity and set DefaultCooldown to 0, along with changing MaxSize to DesiredCapacity
- Wait and Identitify the new node in the cluster
- Wait for the new node to be Ready in Kubernetes
- Drain the node using the `drain` command of `dextre`
- Terminate the old instance and decrement the DesiredCapacity 
- Wait for the node to terminate
- Restore AWS AutoScaling Group defaults
- Sleep 5 seconds for now

Repeat.

Further changes in ui package and more.
