### PR TITLE
let the flow continue and output errors in roll pods flow

### DIFF
--- a/pkg/roll/pods.go
+++ b/pkg/roll/pods.go
@@ -76,5 +76,5 @@ func rollPods(kubectl *kubernetes.Client, pods []v1.Pod, gracePeriod time.Durati
 		}
 		table.DiscardRow()
 	}
-	return nil
+	return
 }


### PR DESCRIPTION
This PR handles the rollPods flow a bit better by continuing if a roll fails, and then continues the flow and outputs the error