### PR TITLE
feat: add aws-region argument to drain

### DIFF
--- a/cmd/drain/drain.go
+++ b/cmd/drain/drain.go
@@ -9,10 +9,11 @@ import (
 )
 
 var (
-	nodeName       string
-	gracePeriod    time.Duration
-	skipValidation bool
-	nodeTermination	 bool
+	nodeName        string
+	gracePeriod     time.Duration
+	skipValidation  bool
+	nodeTermination bool
+	awsRegion       string
 )
 
 // NewCommand sets up the move command
@@ -22,7 +23,7 @@ func NewCommand(kubectl *kubernetes.Client, verbose *bool) *cobra.Command {
 		Short: "",
 		Long:  "",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return drain.Run(kubectl, nodeName, gracePeriod, skipValidation, nodeTermination, *verbose)
+			return drain.Run(kubectl, nodeName, gracePeriod, skipValidation, nodeTermination, awsRegion, *verbose)
 		},
 	}
 	c.Flags().StringVar(&nodeName, "node", "", "The node that dextre should drain in a safe manner (required)")
@@ -30,6 +31,7 @@ func NewCommand(kubectl *kubernetes.Client, verbose *bool) *cobra.Command {
 	c.Flags().BoolVar(&skipValidation, "skip-validation", false, "Don't ask for validations")
 	c.Flags().BoolVar(&nodeTermination, "terminate-node", false, "Terminate the AWS instance in the autoscaling group")
 	c.Flags().DurationVar(&gracePeriod, "grace-period", (30 * time.Second), "pod grace-period")
+	c.Flags().StringVar(&awsRegion, "aws-region", "us-west-1", "The region to use for node")
 
 	return c
 }

--- a/cmd/roll/nodes.go
+++ b/cmd/roll/nodes.go
@@ -24,7 +24,7 @@ func nodesCommand(kubectl *kubernetes.Client, verbose *bool) *cobra.Command {
 	c.MarkFlagRequired("kops-instance-group")
 	c.Flags().StringVar(&label, "label", "", "label of the nodes to be rolled")
 	c.Flags().StringVar(&cluster, "cluster", "", "the name of the kops cluster")
-	c.Flags().StringVar(&awsRegion, "aws-region", "us-west-1", "the region to use")
+	c.Flags().StringVar(&awsRegion, "aws-region", "ue-west-1", "the region to use")
 	c.MarkFlagRequired("cluster")
 
 	return c

--- a/cmd/roll/nodes.go
+++ b/cmd/roll/nodes.go
@@ -10,19 +10,21 @@ import (
 func nodesCommand(kubectl *kubernetes.Client, verbose *bool) *cobra.Command {
 	var instanceGroup string
 	var cluster string
+	var awsRegion string
 
 	c := &cobra.Command{
 		Use:   "nodes",
 		Short: "",
 		Long:  "",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return roll.Nodes(kubectl, instanceGroup, cluster, *verbose)
+			return roll.Nodes(kubectl, instanceGroup, cluster, awsRegion, *verbose)
 		},
 	}
 	c.Flags().StringVar(&instanceGroup, "kops-instance-group", "", "kops instance group to perfrom the rolling on")
 	c.MarkFlagRequired("kops-instance-group")
 	c.Flags().StringVar(&label, "label", "", "label of the nodes to be rolled")
 	c.Flags().StringVar(&cluster, "cluster", "", "the name of the kops cluster")
+	c.Flags().StringVar(&awsRegion, "aws-region", "us-west-1", "the region to use")
 	c.MarkFlagRequired("cluster")
 
 	return c

--- a/pkg/drain/drain.go
+++ b/pkg/drain/drain.go
@@ -12,7 +12,7 @@ import (
 )
 
 //Run: executes the drain command
-func Run(kubectl *kubernetes.Client, nodeName string, gracePeriod time.Duration, skipValidation, nodeTermination, verbose bool) error {
+func Run(kubectl *kubernetes.Client, nodeName string, gracePeriod time.Duration, skipValidation, nodeTermination bool, awsRegion string, verbose bool) error {
 
 	// Find the node in the cluster
 	node, err := kubectl.GetNode(nodeName)
@@ -98,7 +98,7 @@ func Run(kubectl *kubernetes.Client, nodeName string, gracePeriod time.Duration,
 	ui.PrintTitle("Node termination:\n", verbose)
 
 	// Create the client
-	client, err := dextreaws.NewClient("eu-west-1")
+	client, err := dextreaws.NewClient(awsRegion)
 
 	if err != nil {
 		return err

--- a/pkg/roll/nodes.go
+++ b/pkg/roll/nodes.go
@@ -3,17 +3,18 @@ package roll
 import (
 	"fmt"
 	"time"
+
+	"github.com/briandowns/spinner"
 	dextreaws "github.com/lunarway/dextre/pkg/aws"
 	"github.com/lunarway/dextre/pkg/drain"
 	"github.com/lunarway/dextre/pkg/kubernetes"
 	"github.com/lunarway/dextre/pkg/ui"
-	"k8s.io/api/core/v1"
-	"github.com/briandowns/spinner"
+	v1 "k8s.io/api/core/v1"
 )
 
 //Run: executes the drain command
-func Nodes(kubectl *kubernetes.Client, instanceGroup, cluster string, verbose bool) error {
-	
+func Nodes(kubectl *kubernetes.Client, instanceGroup, cluster string, awsRegion string, verbose bool) error {
+
 	spinner := spinner.New(spinner.CharSets[9], 100*time.Millisecond)
 
 	// Get nodes in the kubernetes cluster
@@ -34,14 +35,14 @@ func Nodes(kubectl *kubernetes.Client, instanceGroup, cluster string, verbose bo
 	}
 
 	ui.PrintTitle("OVERVIEW:\n", true)
-	ui.Print(fmt.Sprintf("Nodes to be rolled: %d", len(rollableNodes)),true)
+	ui.Print(fmt.Sprintf("Nodes to be rolled: %d", len(rollableNodes)), true)
 	for _, node := range rollableNodes {
-		ui.Print(fmt.Sprintf("> %s",node.Name),true)
+		ui.Print(fmt.Sprintf("> %s", node.Name), true)
 	}
-	ui.Print(fmt.Sprintf("Discarded nodes: %d", len(discardedNodes)),true)
+	ui.Print(fmt.Sprintf("Discarded nodes: %d", len(discardedNodes)), true)
 
-	ui.Print("",true)
-	ui.PrintTitle("PROGRESS:\n",true)
+	ui.Print("", true)
+	ui.PrintTitle("PROGRESS:\n", true)
 
 	// Create AWS client
 	client, err := dextreaws.NewClient("eu-west-1")
@@ -51,7 +52,7 @@ func Nodes(kubectl *kubernetes.Client, instanceGroup, cluster string, verbose bo
 
 	for _, node := range rollableNodes {
 		spinner.Start()
-		ui.PrintTitle(fmt.Sprintf("[-] %s:",node.Name),true)
+		ui.PrintTitle(fmt.Sprintf("[-] %s:", node.Name), true)
 
 		// Get the list of current nodes in the cluster
 		nodes, err = kubectl.ListNodes()
@@ -64,31 +65,31 @@ func Nodes(kubectl *kubernetes.Client, instanceGroup, cluster string, verbose bo
 		if err != nil {
 			return err
 		}
-		ui.Print(fmt.Sprintf("[✓] AWS Autoscaling group located: %s",asg.AutoScalingGroupName), true)
+		ui.Print(fmt.Sprintf("[✓] AWS Autoscaling group located: %s", asg.AutoScalingGroupName), true)
 
 		// Increment the desired number of instances
 		err = client.IncrementCapacity(asg)
 		if err != nil {
 			return err
 		}
-		ui.Print(fmt.Sprintf("[✓] Increasing DesiredCapacity of %s from %d nodes to %d nodes and DefaultCooldown to %d",asg.AutoScalingGroupName, asg.DesiredCapacity, asg.DesiredCapacity+1,0), true)
+		ui.Print(fmt.Sprintf("[✓] Increasing DesiredCapacity of %s from %d nodes to %d nodes and DefaultCooldown to %d", asg.AutoScalingGroupName, asg.DesiredCapacity, asg.DesiredCapacity+1, 0), true)
 
 		// Wait and identify the new node
 		newNode, err := kubectl.IdentifyNewNode(nodes.Items, instanceGroup)
 		if err != nil {
 			return err
 		}
-		ui.Print(fmt.Sprintf("[✓] %s added to the cluster",newNode.Name), true)
+		ui.Print(fmt.Sprintf("[✓] %s added to the cluster", newNode.Name), true)
 
 		// Wait for the new node to enter Ready state
 		err = kubectl.WaitForNewNodeToBeReady(newNode)
 		if err != nil {
 			return err
 		}
-		ui.Print(fmt.Sprintf("[✓] %s is now in state: Ready",newNode.Name), true)
+		ui.Print(fmt.Sprintf("[✓] %s is now in state: Ready", newNode.Name), true)
 
 		// Drain the Node
-		drain.Run(kubectl, node.Name, 30, true, false, verbose)
+		drain.Run(kubectl, node.Name, 30, true, false, awsRegion, verbose)
 
 		// Get the AWS InstanceId
 		instanceID, err := client.GetInstanceId(node.Name)
@@ -101,24 +102,24 @@ func Nodes(kubectl *kubernetes.Client, instanceGroup, cluster string, verbose bo
 		if err != nil {
 			return err
 		}
-		ui.Print(fmt.Sprintf("[✓] %s will now be terminated",node.Name), true)
+		ui.Print(fmt.Sprintf("[✓] %s will now be terminated", node.Name), true)
 
 		// Wait for the node to be terminated
 		err = kubectl.WaitForNodeToTerminate(node)
 		if err != nil {
 			return err
 		}
-		ui.Print(fmt.Sprintf("[✓] %s is now removed from the cluster",node.Name), true)
+		ui.Print(fmt.Sprintf("[✓] %s is now removed from the cluster", node.Name), true)
 
 		// RESTORE ASG MAXSIZE
 		err = client.RestoreValuesForAutoScalingGroup(asg)
 		if err != nil {
 			return err
 		}
-		ui.Print(fmt.Sprintf("[✓] Restored AutoScalingGroup %s defaults. MaxSize=%d and DefaultCooldown=%d",asg.AutoScalingGroupName, asg.MaxSize, asg.DefaultCooldown), true)
+		ui.Print(fmt.Sprintf("[✓] Restored AutoScalingGroup %s defaults. MaxSize=%d and DefaultCooldown=%d", asg.AutoScalingGroupName, asg.MaxSize, asg.DefaultCooldown), true)
 
 		// Interval between node roll
-		time.Sleep(5 * time.Second) 
+		time.Sleep(5 * time.Second)
 		spinner.Stop()
 	}
 

--- a/pkg/roll/nodes.go
+++ b/pkg/roll/nodes.go
@@ -45,7 +45,7 @@ func Nodes(kubectl *kubernetes.Client, instanceGroup, cluster string, awsRegion 
 	ui.PrintTitle("PROGRESS:\n", true)
 
 	// Create AWS client
-	client, err := dextreaws.NewClient("eu-west-1")
+	client, err := dextreaws.NewClient(awsRegion)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Add  `--aws-region` for drain command. 

```
$dextre  drain -h
Usage:
  dextre drain [flags]

Flags:
      --aws-region string       The region to use for node (default "us-west-1")
      --grace-period duration   pod grace-period (default 30s)
  -h, --help                    help for drain
      --node string             The node that dextre should drain in a safe manner (required)
      --skip-validation         Don't ask for validations
      --terminate-node          Terminate the AWS instance in the autoscaling group

Global Flags:
      --kubeconfig string   kubeconfig file
      --verbose             verbose output
```